### PR TITLE
comparison operators: add support for `std::string` and `std::string_view`

### DIFF
--- a/include/boost/static_string/static_string.hpp
+++ b/include/boost/static_string/static_string.hpp
@@ -23,7 +23,12 @@
 #include <functional>
 #include <initializer_list>
 #include <iosfwd>
+#include <string>
 #include <type_traits>
+
+#ifndef BOOST_NO_CXX17_HDR_STRING_VIEW
+#include <string_view>
+#endif
 
 namespace boost {
 namespace static_strings {
@@ -5613,6 +5618,331 @@ operator+(
   return basic_static_string<N + M, CharT, Traits>(rhs).insert(
     std::size_t(0), +lhs);
 }
+
+
+//------------------------------------------------------------------------------
+//
+// std::string/std::string_view comparison
+//
+//------------------------------------------------------------------------------
+
+template<std::size_t N, typename CharT, typename Traits, typename Alloc>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator==(
+  const std::basic_string<CharT, Traits, Alloc>& lhs,
+  const basic_static_string<N, CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) == 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits, typename Alloc>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator==(
+  const basic_static_string<N, CharT, Traits>& lhs,
+  const std::basic_string<CharT, Traits, Alloc>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) == 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits, typename Alloc>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator!=(
+  const std::basic_string<CharT, Traits, Alloc>& lhs,
+  const basic_static_string<N, CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) != 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits, typename Alloc>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator!=(
+  const basic_static_string<N, CharT, Traits>& lhs,
+  const std::basic_string<CharT, Traits, Alloc>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) != 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits, typename Alloc>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator<(
+  const std::basic_string<CharT, Traits, Alloc>& lhs,
+  const basic_static_string<N, CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) < 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits, typename Alloc>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator<(
+  const basic_static_string<N, CharT, Traits>& lhs,
+  const std::basic_string<CharT, Traits, Alloc>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) < 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits, typename Alloc>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator<=(
+  const std::basic_string<CharT, Traits, Alloc>& lhs,
+  const basic_static_string<N, CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) <= 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits, typename Alloc>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator<=(
+  const basic_static_string<N, CharT, Traits>& lhs,
+  const std::basic_string<CharT, Traits, Alloc>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) <= 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits, typename Alloc>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator>(
+  const std::basic_string<CharT, Traits, Alloc>& lhs,
+  const basic_static_string<N, CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) > 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits, typename Alloc>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator>(
+  const basic_static_string<N, CharT, Traits>& lhs,
+  const std::basic_string<CharT, Traits, Alloc>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) > 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits, typename Alloc>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator>=(
+  const std::basic_string<CharT, Traits, Alloc>& lhs,
+  const basic_static_string<N, CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) >= 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits, typename Alloc>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator>=(
+  const basic_static_string<N, CharT, Traits>& lhs,
+  const std::basic_string<CharT, Traits, Alloc>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) >= 0;
+}
+
+
+#ifndef BOOST_NO_CXX17_HDR_STRING_VIEW
+
+template<std::size_t N, typename CharT, typename Traits>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator==(
+  const std::basic_string_view<CharT, Traits>& lhs,
+  const basic_static_string<N, CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) == 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator==(
+  const basic_static_string<N, CharT, Traits>& lhs,
+  const std::basic_string_view<CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) == 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator!=(
+  const std::basic_string_view<CharT, Traits>& lhs,
+  const basic_static_string<N, CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) != 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator!=(
+  const basic_static_string<N, CharT, Traits>& lhs,
+  const std::basic_string_view<CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) != 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator<(
+  const std::basic_string_view<CharT, Traits>& lhs,
+  const basic_static_string<N, CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) < 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator<(
+  const basic_static_string<N, CharT, Traits>& lhs,
+  const std::basic_string_view<CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) < 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator<=(
+  const std::basic_string_view<CharT, Traits>& lhs,
+  const basic_static_string<N, CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) <= 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator<=(
+  const basic_static_string<N, CharT, Traits>& lhs,
+  const std::basic_string_view<CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) <= 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator>(
+  const std::basic_string_view<CharT, Traits>& lhs,
+  const basic_static_string<N, CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) > 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator>(
+  const basic_static_string<N, CharT, Traits>& lhs,
+  const std::basic_string_view<CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) > 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator>=(
+  const std::basic_string_view<CharT, Traits>& lhs,
+  const basic_static_string<N, CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) >= 0;
+}
+
+template<std::size_t N, typename CharT, typename Traits>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+inline
+bool
+operator>=(
+  const basic_static_string<N, CharT, Traits>& lhs,
+  const std::basic_string_view<CharT, Traits>& rhs)
+{
+  return detail::lexicographical_compare<CharT, Traits>(
+    lhs.data(), lhs.size(),
+    rhs.data(), rhs.size()) >= 0;
+}
+
+#endif
+
 
 //------------------------------------------------------------------------------
 //

--- a/test/static_string.cpp
+++ b/test/static_string.cpp
@@ -3543,6 +3543,51 @@ testCompare()
     BOOST_TEST(testC(S("abcdefghijklmnopqrst"), 21, 0, "abcdefghijklmnopqrst", 10, 0));
     BOOST_TEST(testC(S("abcdefghijklmnopqrst"), 21, 0, "abcdefghijklmnopqrst", 19, 0));
     BOOST_TEST(testC(S("abcdefghijklmnopqrst"), 21, 0, "abcdefghijklmnopqrst", 20, 0));
+
+    {
+        std::string sv1 = "x";
+        std::string sv2 = "y";
+        str1 s1("x");
+        str2 s2("y");
+
+        BOOST_TEST(sv1 <= s2);
+        BOOST_TEST(sv1 < s2);
+        BOOST_TEST(sv1 != s2);
+        BOOST_TEST(! (sv1 == s2));
+        BOOST_TEST(! (sv1 >= s2));
+        BOOST_TEST(! (sv1 > s2));
+
+        BOOST_TEST(s1 <= sv2);
+        BOOST_TEST(s1 < sv2);
+        BOOST_TEST(s1 != sv2);
+        BOOST_TEST(! (s1 == sv2));
+        BOOST_TEST(! (s1 >= sv2));
+        BOOST_TEST(! (s1 > sv2));
+    }
+
+#ifndef BOOST_NO_CXX17_HDR_STRING_VIEW
+    {
+        std::string_view sv1 = "x";
+        std::string_view sv2 = "y";
+        str1 s1("x");
+        str2 s2("y");
+
+        BOOST_TEST(sv1 <= s2);
+        BOOST_TEST(sv1 < s2);
+        BOOST_TEST(sv1 != s2);
+        BOOST_TEST(! (sv1 == s2));
+        BOOST_TEST(! (sv1 >= s2));
+        BOOST_TEST(! (sv1 > s2));
+
+        BOOST_TEST(s1 <= sv2);
+        BOOST_TEST(s1 < sv2);
+        BOOST_TEST(s1 != sv2);
+        BOOST_TEST(! (s1 == sv2));
+        BOOST_TEST(! (s1 >= sv2));
+        BOOST_TEST(! (s1 > sv2));
+    }
+#endif
+
 }
 
 // done


### PR DESCRIPTION
`static_string` lacks the comparison operators to interact with
`std::string` and `std::string_view`. this limits its usefulness when
interacting with these types. e.g. when using a `string_view` to perform
a lookup in a `std::map<static_string, ...>`