### PR TITLE
string_view interoperability

### DIFF
--- a/test/constexpr_tests.hpp
+++ b/test/constexpr_tests.hpp
@@ -357,8 +357,10 @@ testConstantEvaluation()
   a.substr(0);
 #endif
 
+#ifdef BOOST_STATIC_STRING_HAS_STRING_VIEW
   // subview
   a.subview(0);
+#endif
 
   // copy
   char k[20]{};


### PR DESCRIPTION
fix #26

This PR includes interoperability with `std::string_view` and `core::string_view`.

- Interoperability with `std::string_view` is enabled not only for standalone mode now. This means the string_view operations are now independent of the default `static_strings::basic_string_view` type.
- Interoperability with `core::string_view` now allows conversions from and to more types than `boost::string_view`. This is especially useful when `std::string_view` is unavailable.
- Interoperability with `boost::string_view` is maintained. Removing it would break things. For instance, any type `T` convertible to `boost::string_view`, like we have in unit tests.
- Interoperability with string-like types is used when no other string_view-like type is available. For instance, in our test "Clang 3.8: C++11 Standalone" that currently exists in CI, which has no string_view-type available. The question now is why these tests weren't failing before.
- The comparison operators and implicit conversions are now available for all these string_view types
- No explicit conversion to `std::string` has been implemented as the library does not include `<string>`