### PR TITLE
Don't use an additional buffer in the arithmetic conversions

### DIFF
--- a/include/boost/static_string/static_string.hpp
+++ b/include/boost/static_string/static_string.hpp
@@ -549,11 +549,14 @@ inline
 static_string<N>
 to_static_string_int_impl(Integer value) noexcept
 {
-  char buffer[N];
-  const auto digits_end = std::end(buffer);
-  const auto digits_begin = integer_to_string<std::char_traits<char>, Integer>(
+  static_string<N> result;
+  char * const digits_end = result.data() + N;
+  char * const digits_begin = integer_to_string<std::char_traits<char>, Integer>(
     digits_end, value, std::is_signed<Integer>{});
-  return static_string<N>(digits_begin, std::distance(digits_begin, digits_end));
+  result.set_size(digits_end - digits_begin);
+  std::char_traits<char>::move(result.data(), digits_begin, result.size());
+  result.term();
+  return result;
 }
 
 #ifdef BOOST_STATIC_STRING_HAS_WCHAR
@@ -562,11 +565,14 @@ inline
 static_wstring<N>
 to_static_wstring_int_impl(Integer value) noexcept
 {
-  wchar_t buffer[N];
-  const auto digits_end = std::end(buffer);
-  const auto digits_begin = integer_to_wstring<std::char_traits<wchar_t>, Integer>(
+  static_wstring<N> result;
+  wchar_t * const digits_end = result.data() + N;
+  wchar_t * const digits_begin = integer_to_wstring<std::char_traits<wchar_t>, Integer>(
     digits_end, value, std::is_signed<Integer>{});
-  return static_wstring<N>(digits_begin, std::distance(digits_begin, digits_end));
+  result.set_size(digits_end - digits_begin);
+  std::char_traits<wchar_t>::move(result.data(), digits_begin, result.size());
+  result.term();
+  return result;
 }
 #endif
 
@@ -595,11 +601,11 @@ to_static_string_float_impl(double value) noexcept
   // will require more than 2^63 chars to represent a float value.
   const long long narrow =
     static_cast<long long>(N);
-  // extra one needed for null terminator
-  char buffer[N + 1];
+  static_string<N> result;
   // we know that a formatting error will not occur, so
   // we assume that the result is always positive
-  if (std::size_t(std::snprintf(buffer, N + 1, "%f", value)) > N)
+  std::size_t length = std::snprintf(result.data(), N + 1, "%f", value);
+  if (length > N)
   {
     // the + 4 is for the decimal, 'e',
     // its sign, and the sign of the integral portion
@@ -609,10 +615,10 @@ to_static_string_float_impl(double value) noexcept
     const int precision = narrow > reserved_count ?
       N - reserved_count : 0;
     // switch to scientific notation
-    std::snprintf(buffer, N + 1, "%.*e", precision, value);
+    length = std::snprintf(result.data(), N + 1, "%.*e", precision, value);
   }
-  // this will not throw
-  return static_string<N>(buffer);
+  result.set_size(length);
+  return result;
 }
 
 template<std::size_t N>
@@ -624,13 +630,13 @@ to_static_string_float_impl(long double value) noexcept
   // will require more than 2^63 chars to represent a float value.
   const long long narrow =
     static_cast<long long>(N);
-  // extra one needed for null terminator
-  char buffer[N + 1];
+  static_string<N> result;
   // snprintf returns the number of characters
   // that would have been written
   // we know that a formatting error will not occur, so
   // we assume that the result is always positive
-  if (std::size_t(std::snprintf(buffer, N + 1, "%Lf", value)) > N)
+  std::size_t length = std::snprintf(result.data(), N + 1, "%Lf", value);
+  if (length > N)
   {
     // the + 4 is for the decimal, 'e',
     // its sign, and the sign of the integral portion
@@ -640,10 +646,10 @@ to_static_string_float_impl(long double value) noexcept
     const int precision = narrow > reserved_count ?
       N - reserved_count : 0;
     // switch to scientific notation
-    std::snprintf(buffer, N + 1, "%.*Le", precision, value);
+    length = std::snprintf(result.data(), N + 1, "%.*Le", precision, value);
   }
-  // this will not throw
-  return static_string<N>(buffer);
+  result.set_size(length);
+  return result;
 }
 
 #ifdef BOOST_STATIC_STRING_HAS_WCHAR
@@ -656,8 +662,7 @@ to_static_wstring_float_impl(double value) noexcept
   // will require more than 2^63 chars to represent a float value.
   const long long narrow =
     static_cast<long long>(N);
-  // extra one needed for null terminator
-  wchar_t buffer[N + 1];
+  static_wstring<N> result;
   // swprintf returns a negative number if it can't
   // fit all the characters in the buffer.
   // mingw has a non-standard swprintf, so
@@ -665,8 +670,8 @@ to_static_wstring_float_impl(double value) noexcept
   // circuit evaluation will ensure that the
   // second operand is not evaluated on conforming
   // implementations.
-  const long long num_written =
-    std::swprintf(buffer, N + 1, L"%f", value);
+  long long num_written =
+    std::swprintf(result.data(), N + 1, L"%f", value);
   if (num_written < 0 ||
     num_written > narrow)
   {
@@ -678,10 +683,10 @@ to_static_wstring_float_impl(double value) noexcept
     const int precision = narrow > reserved_count ?
       N - reserved_count : 0;
     // switch to scientific notation
-    std::swprintf(buffer, N + 1, L"%.*e", precision, value);
+    num_written = std::swprintf(result.data(), N + 1, L"%.*e", precision, value);
   }
-  // this will not throw
-  return static_wstring<N>(buffer);
+  result.set_size(static_cast<std::size_t>(num_written));
+  return result;
 }
 
 template<std::size_t N>
@@ -693,8 +698,7 @@ to_static_wstring_float_impl(long double value) noexcept
   // will require more than 2^63 chars to represent a float value.
   const long long narrow =
     static_cast<long long>(N);
-  // extra one needed for null terminator
-  wchar_t buffer[N + 1];
+  static_wstring<N> result;
   // swprintf returns a negative number if it can't
   // fit all the characters in the buffer.
   // mingw has a non-standard swprintf, so
@@ -702,8 +706,8 @@ to_static_wstring_float_impl(long double value) noexcept
   // circuit evaluation will ensure that the
   // second operand is not evaluated on conforming
   // implementations.
-  const long long num_written =
-    std::swprintf(buffer, N + 1, L"%Lf", value);
+  long long num_written =
+    std::swprintf(result.data(), N + 1, L"%Lf", value);
   if (num_written < 0 ||
     num_written > narrow)
   {
@@ -715,10 +719,10 @@ to_static_wstring_float_impl(long double value) noexcept
     const int precision = narrow > reserved_count ?
       N - reserved_count : 0;
     // switch to scientific notation
-    std::swprintf(buffer, N + 1, L"%.*Le", precision, value);
+    num_written = std::swprintf(result.data(), N + 1, L"%.*Le", precision, value);
   }
-  // this will not throw
-  return static_wstring<N>(buffer);
+  result.set_size(static_cast<std::size_t>(num_written));
+  return result;
 }
 #endif
 
@@ -925,6 +929,37 @@ class basic_static_string
 private:
   template<std::size_t, class, class>
   friend class basic_static_string;
+
+  template<std::size_t P, typename Integer>
+  friend
+  static_string<P>
+  detail::to_static_string_int_impl(Integer value) noexcept;
+
+  template<std::size_t P>
+  friend
+  static_string<P>
+  detail::to_static_string_float_impl(double value) noexcept;
+
+  template<std::size_t P>
+  friend
+  static_string<P>
+  detail::to_static_string_float_impl(long double value) noexcept;
+
+#ifdef BOOST_STATIC_STRING_HAS_WCHAR
+  template<std::size_t P, typename Integer>
+  friend static_wstring<P>
+  detail::to_static_wstring_int_impl(Integer value) noexcept;
+
+  template<std::size_t P>
+  friend
+  static_wstring<P>
+  detail::to_static_wstring_float_impl(double value) noexcept;
+
+  template<std::size_t P>
+  friend
+  static_wstring<P>
+  detail::to_static_wstring_float_impl(long double value) noexcept;
+#endif
 public:
   //--------------------------------------------------------------------------
   //

--- a/include/boost/static_string/static_string.hpp
+++ b/include/boost/static_string/static_string.hpp
@@ -550,13 +550,21 @@ inline
 static_string<N>
 to_static_string_int_impl(Integer value) noexcept
 {
+  using size_type = typename static_string<N>::size_type;
   static_string<N> result;
-  char * const digits_end = result.data() + N;
-  char * const digits_begin = integer_to_string<std::char_traits<char>, Integer>(
-    digits_end, value, std::is_signed<Integer>{});
-  result.set_size(digits_end - digits_begin);
-  std::char_traits<char>::move(result.data(), digits_begin, result.size());
-  result.term();
+  result.resize_and_overwrite(
+    N, 
+    [&](char* buffer, size_type) -> size_type
+    {
+      char* const digits_end = buffer + N;
+      char* const digits_begin = integer_to_string<std::char_traits<char>, Integer>(
+          digits_end, value, std::is_signed<Integer>{});
+      const size_type len = digits_end - digits_begin;
+      std::char_traits<char>::move(buffer, digits_begin, len);
+      return len;
+    }
+  );
+
   return result;
 }
 
@@ -566,13 +574,20 @@ inline
 static_wstring<N>
 to_static_wstring_int_impl(Integer value) noexcept
 {
+  using size_type = typename static_wstring<N>::size_type;
   static_wstring<N> result;
-  wchar_t * const digits_end = result.data() + N;
-  wchar_t * const digits_begin = integer_to_wstring<std::char_traits<wchar_t>, Integer>(
-    digits_end, value, std::is_signed<Integer>{});
-  result.set_size(digits_end - digits_begin);
-  std::char_traits<wchar_t>::move(result.data(), digits_begin, result.size());
-  result.term();
+  result.resize_and_overwrite(
+    N,
+    [&](wchar_t* buffer, size_type) -> size_type
+    {
+      wchar_t* const digits_end = buffer + N;
+      wchar_t* const digits_begin = integer_to_wstring<std::char_traits<wchar_t>, Integer>(
+          digits_end, value, std::is_signed<Integer>{});
+      const size_type len = digits_end - digits_begin;
+      std::char_traits<wchar_t>::move(buffer, digits_begin, len);
+      return len;
+    }
+  );
   return result;
 }
 #endif
@@ -598,27 +613,34 @@ inline
 static_string<N>
 to_static_string_float_impl(double value) noexcept
 {
+  using size_type = typename static_string<N>::size_type;
   // we have to assume here that no reasonable implementation
   // will require more than 2^63 chars to represent a float value.
   const long long narrow =
     static_cast<long long>(N);
   static_string<N> result;
-  // we know that a formatting error will not occur, so
-  // we assume that the result is always positive
-  std::size_t length = std::snprintf(result.data(), N + 1, "%f", value);
-  if (length > N)
-  {
-    // the + 4 is for the decimal, 'e',
-    // its sign, and the sign of the integral portion
-    const int reserved_count =
-      (std::max)(2, count_digits(
-      std::numeric_limits<double>::max_exponent10)) + 4;
-    const int precision = narrow > reserved_count ?
-      N - reserved_count : 0;
-    // switch to scientific notation
-    length = std::snprintf(result.data(), N + 1, "%.*e", precision, value);
-  }
-  result.set_size(length);
+  result.resize_and_overwrite(
+    N,
+    [&](char* buffer, size_type) -> size_type
+    {
+      // we know that a formatting error will not occur, so
+      // we assume that the result is always positive
+      std::size_t length = std::snprintf(buffer, N + 1, "%f", value);
+      if (length > N)
+      {
+        // the + 4 is for the decimal, 'e',
+        // its sign, and the sign of the integral portion
+        const int reserved_count =
+            (std::max)(2, count_digits(
+                std::numeric_limits<double>::max_exponent10)) + 4;
+        const int precision = narrow > reserved_count ?
+            N - reserved_count : 0;
+        // switch to scientific notation
+        length = std::snprintf(buffer, N + 1, "%.*e", precision, value);
+      }
+      return length;
+    }
+  );
   return result;
 }
 
@@ -627,29 +649,36 @@ inline
 static_string<N>
 to_static_string_float_impl(long double value) noexcept
 {
+  using size_type = typename static_string<N>::size_type;
   // we have to assume here that no reasonable implementation
   // will require more than 2^63 chars to represent a float value.
   const long long narrow =
     static_cast<long long>(N);
   static_string<N> result;
-  // snprintf returns the number of characters
-  // that would have been written
-  // we know that a formatting error will not occur, so
-  // we assume that the result is always positive
-  std::size_t length = std::snprintf(result.data(), N + 1, "%Lf", value);
-  if (length > N)
-  {
-    // the + 4 is for the decimal, 'e',
-    // its sign, and the sign of the integral portion
-    const int reserved_count =
-      (std::max)(2, count_digits(
-      std::numeric_limits<long double>::max_exponent10)) + 4;
-    const int precision = narrow > reserved_count ?
-      N - reserved_count : 0;
-    // switch to scientific notation
-    length = std::snprintf(result.data(), N + 1, "%.*Le", precision, value);
-  }
-  result.set_size(length);
+  result.resize_and_overwrite(
+    N,
+    [&](char* buffer, size_type)->size_type
+    {
+      // snprintf returns the number of characters
+      // that would have been written
+      // we know that a formatting error will not occur, so
+      // we assume that the result is always positive
+      std::size_t length = std::snprintf(buffer, N + 1, "%Lf", value);
+      if (length > N)
+      {
+          // the + 4 is for the decimal, 'e',
+          // its sign, and the sign of the integral portion
+          const int reserved_count =
+              (std::max)(2, count_digits(
+                  std::numeric_limits<long double>::max_exponent10)) + 4;
+          const int precision = narrow > reserved_count ?
+              N - reserved_count : 0;
+          // switch to scientific notation
+          length = std::snprintf(buffer, N + 1, "%.*Le", precision, value);
+      }
+      return length;
+    }
+  );
   return result;
 }
 
@@ -659,34 +688,41 @@ inline
 static_wstring<N>
 to_static_wstring_float_impl(double value) noexcept
 {
+  using size_type = typename static_wstring<N>::size_type;
   // we have to assume here that no reasonable implementation
   // will require more than 2^63 chars to represent a float value.
   const long long narrow =
     static_cast<long long>(N);
   static_wstring<N> result;
-  // swprintf returns a negative number if it can't
-  // fit all the characters in the buffer.
-  // mingw has a non-standard swprintf, so
-  // this just covers all the bases. short
-  // circuit evaluation will ensure that the
-  // second operand is not evaluated on conforming
-  // implementations.
-  long long num_written =
-    std::swprintf(result.data(), N + 1, L"%f", value);
-  if (num_written < 0 ||
-    num_written > narrow)
-  {
-    // the + 4 is for the decimal, 'e',
-    // its sign, and the sign of the integral portion
-    const int reserved_count =
-      (std::max)(2, count_digits(
-      std::numeric_limits<double>::max_exponent10)) + 4;
-    const int precision = narrow > reserved_count ?
-      N - reserved_count : 0;
-    // switch to scientific notation
-    num_written = std::swprintf(result.data(), N + 1, L"%.*e", precision, value);
-  }
-  result.set_size(static_cast<std::size_t>(num_written));
+  result.resize_and_overwrite(
+    N,
+    [&](wchar_t* buffer, size_type) -> size_type
+    {
+      // swprintf returns a negative number if it can't
+      // fit all the characters in the buffer.
+      // mingw has a non-standard swprintf, so
+      // this just covers all the bases. short
+      // circuit evaluation will ensure that the
+      // second operand is not evaluated on conforming
+      // implementations.
+      long long num_written =
+          std::swprintf(buffer, N + 1, L"%f", value);
+      if (num_written < 0 ||
+          num_written > narrow)
+      {
+          // the + 4 is for the decimal, 'e',
+          // its sign, and the sign of the integral portion
+          const int reserved_count =
+              (std::max)(2, count_digits(
+                  std::numeric_limits<double>::max_exponent10)) + 4;
+          const int precision = narrow > reserved_count ?
+              N - reserved_count : 0;
+          // switch to scientific notation
+          num_written = std::swprintf(buffer, N + 1, L"%.*e", precision, value);
+      }
+      return num_written;
+    }
+  );
   return result;
 }
 
@@ -695,34 +731,41 @@ inline
 static_wstring<N>
 to_static_wstring_float_impl(long double value) noexcept
 {
+  using size_type = typename static_wstring<N>::size_type;
   // we have to assume here that no reasonable implementation
   // will require more than 2^63 chars to represent a float value.
   const long long narrow =
     static_cast<long long>(N);
   static_wstring<N> result;
-  // swprintf returns a negative number if it can't
-  // fit all the characters in the buffer.
-  // mingw has a non-standard swprintf, so
-  // this just covers all the bases. short
-  // circuit evaluation will ensure that the
-  // second operand is not evaluated on conforming
-  // implementations.
-  long long num_written =
-    std::swprintf(result.data(), N + 1, L"%Lf", value);
-  if (num_written < 0 ||
-    num_written > narrow)
-  {
-    // the + 4 is for the decimal, 'e',
-    // its sign, and the sign of the integral portion
-    const int reserved_count =
-      (std::max)(2, count_digits(
-      std::numeric_limits<long double>::max_exponent10)) + 4;
-    const int precision = narrow > reserved_count ?
-      N - reserved_count : 0;
-    // switch to scientific notation
-    num_written = std::swprintf(result.data(), N + 1, L"%.*Le", precision, value);
-  }
-  result.set_size(static_cast<std::size_t>(num_written));
+  result.resize_and_overwrite(
+    N,
+    [&](wchar_t* buffer, size_type) -> size_type
+    {
+      // swprintf returns a negative number if it can't
+      // fit all the characters in the buffer.
+      // mingw has a non-standard swprintf, so
+      // this just covers all the bases. short
+      // circuit evaluation will ensure that the
+      // second operand is not evaluated on conforming
+      // implementations.
+      long long num_written =
+          std::swprintf(buffer, N + 1, L"%Lf", value);
+      if (num_written < 0 ||
+          num_written > narrow)
+      {
+          // the + 4 is for the decimal, 'e',
+          // its sign, and the sign of the integral portion
+          const int reserved_count =
+              (std::max)(2, count_digits(
+                  std::numeric_limits<long double>::max_exponent10)) + 4;
+          const int precision = narrow > reserved_count ?
+              N - reserved_count : 0;
+          // switch to scientific notation
+          num_written = std::swprintf(buffer, N + 1, L"%.*Le", precision, value);
+      }
+      return num_written;
+    }
+  );
   return result;
 }
 #endif
@@ -931,36 +974,6 @@ private:
   template<std::size_t, class, class>
   friend class basic_static_string;
 
-  template<std::size_t P, typename Integer>
-  friend
-  static_string<P>
-  detail::to_static_string_int_impl(Integer value) noexcept;
-
-  template<std::size_t P>
-  friend
-  static_string<P>
-  detail::to_static_string_float_impl(double value) noexcept;
-
-  template<std::size_t P>
-  friend
-  static_string<P>
-  detail::to_static_string_float_impl(long double value) noexcept;
-
-#ifdef BOOST_STATIC_STRING_HAS_WCHAR
-  template<std::size_t P, typename Integer>
-  friend static_wstring<P>
-  detail::to_static_wstring_int_impl(Integer value) noexcept;
-
-  template<std::size_t P>
-  friend
-  static_wstring<P>
-  detail::to_static_wstring_float_impl(double value) noexcept;
-
-  template<std::size_t P>
-  friend
-  static_wstring<P>
-  detail::to_static_wstring_float_impl(long double value) noexcept;
-#endif
 public:
   //--------------------------------------------------------------------------
   //

--- a/include/boost/static_string/static_string.hpp
+++ b/include/boost/static_string/static_string.hpp
@@ -39,6 +39,7 @@
 #include <limits>
 #include <iosfwd>
 #include <type_traits>
+#include <utility>
 
 namespace boost {
 namespace static_strings {
@@ -3743,6 +3744,31 @@ public:
     size_type n,
     value_type c);
 
+  /**
+      Resize the string and overwrite its contents.
+
+      Resizes the string to contain `n` characters, and uses the
+      provided function object `op` to overwrite the string contents.
+      The function object is called with two arguments: a pointer to
+      the string internal buffer, and the size of the string. The
+      function object shall return the number of characters written to
+      the buffer, which shall be less than or equal to `n`. The string
+      size is set to the value returned by the function object.
+
+      @par Exception Safety
+
+      Strong guarantee. However, if an exception is thrown by
+      `std::move(op)(p, count)`, the behavior is undefined.
+
+      @throw std::length_error `n > max_size()`
+  */
+  template<typename Operation>
+  BOOST_STATIC_STRING_CPP14_CONSTEXPR
+  void
+  resize_and_overwrite(
+    size_type n,
+    Operation op);
+
   /** Swap two strings.
 
       Swaps the contents of the string and `s`.
@@ -6690,6 +6716,26 @@ resize(size_type n, value_type c)
   if(n > curr_size)
     traits_type::assign(data() + curr_size, n - curr_size, c);
   this->set_size(n);
+  term();
+}
+
+template<std::size_t N, typename CharT, typename Traits>
+template<typename Operation>
+BOOST_STATIC_STRING_CPP14_CONSTEXPR
+void
+basic_static_string<N, CharT, Traits>::
+resize_and_overwrite(
+  size_type n,
+  Operation op)
+{
+  if (n > max_size()) {
+    detail::throw_exception<std::length_error>("n > max_size() in resize_and_overwrite()");
+  }
+
+  CharT* p = data();
+  const auto new_size = std::move(op)(p, n);
+  BOOST_STATIC_STRING_ASSERT(new_size >= 0 && size_type(new_size) <= n);
+  this->set_size(size_type(new_size));
   term();
 }
 

--- a/test/static_string.cpp
+++ b/test/static_string.cpp
@@ -7421,6 +7421,68 @@ testResize()
 }
 
 void
+testResizeAndOverwrite()
+{
+  {
+    // Basic overwrite
+    static_string<16> s;
+    s.resize_and_overwrite(
+      5,
+      [](char* buf, std::size_t) -> std::size_t
+      {
+        std::strcpy(buf, "Hello");
+        return 5;
+      }
+    );
+    BOOST_TEST(s.size() == 5);
+    BOOST_TEST(s == "Hello");
+  }
+  {
+    // Zero overwrite
+    static_string<16> s;
+    s.resize_and_overwrite(
+      8,
+      [](char*, std::size_t) -> std::size_t
+      {
+        return 0;
+      }
+    );
+    BOOST_TEST(s.empty());
+  }
+  {
+    // Maximum size overwrite
+    constexpr std::size_t N = 16;
+    static_string<N> s;
+    s.resize_and_overwrite(
+      N,
+      [](char* buf, std::size_t n) -> std::size_t
+      {
+        for (std::size_t i = 0; i < n; ++i) {
+          buf[i] = 'x';
+        }
+        return n;
+      }
+    );
+    BOOST_TEST(s.size() == N);
+    BOOST_TEST(s == std::string(N, 'x'));
+  }
+  {
+    // Oversize overwrite
+    static_string<16> s;
+    BOOST_TEST_THROWS(
+      s.resize_and_overwrite(
+        17,
+        [](char*, std::size_t n) -> std::size_t
+        {
+          return n;
+        }
+      ),
+      std::length_error
+    );
+  }
+}
+
+void
 testStream()
 {
   std::stringstream a;
@@ -7539,6 +7601,7 @@ runTests()
   testGeneral();
   testToStaticString();
   testResize();
+  testResizeAndOverwrite();
 
   testFind();
 


### PR DESCRIPTION
In the case of the floating point conversions, this effectively avoids a copy of the buffer contents. In the case of the integer conversions, it doesn't eliminate the copy, but still removes the extra buffer.