### PR TITLE
Fix standalone build

### DIFF
--- a/include/boost/static_string/config.hpp
+++ b/include/boost/static_string/config.hpp
@@ -168,27 +168,31 @@
 #include <cassert>
 #include <stdexcept>
 
+#if defined(__has_include)
+#  if !__has_include(<string_view>)
+#    define BOOST_STATIC_STRING_NO_CXX17_HDR_STRING_VIEW
+#  endif
 /*
  * Replicate the logic from Boost.Config
  */
 // GNU libstdc++3:
-#if defined(__GLIBCPP__) || defined(__GLIBCXX__)
-#if (BOOST_LIBSTDCXX_VERSION < 70100) || (__cplusplus <= 201402L)
-#  define BOOST_STATIC_STRING_NO_CXX17_HDR_STRING_VIEW
-#endif
+#elif defined(__GLIBCPP__) || defined(__GLIBCXX__)
+#  if ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 70100) || (__cplusplus <= 201402L)
+#    define BOOST_STATIC_STRING_NO_CXX17_HDR_STRING_VIEW
+#  endif
 // libc++:
 #elif defined(_LIBCPP_VERSION)
-#if (_LIBCPP_VERSION < 4000) || (__cplusplus <= 201402L)
-#  define BOOST_STATIC_STRING_NO_CXX17_HDR_STRING_VIEW
-#endif
+#  if (_LIBCPP_VERSION < 4000) || (__cplusplus <= 201402L)
+#    define BOOST_STATIC_STRING_NO_CXX17_HDR_STRING_VIEW
+#  endif
 // MSVC uses logic from catch all for BOOST_NO_CXX17_HDR_STRING_VIEW
 // catch all:
 #elif !defined(_YVALS) && !defined(_CPPLIB_VER)
-#if (!defined(__has_include) || (__cplusplus < 201700))
-#  define BOOST_STATIC_STRING_NO_CXX17_HDR_STRING_VIEW
-#elif !__has_include(<string_view>)
-#  define BOOST_STATIC_STRING_NO_CXX17_HDR_STRING_VIEW
-#endif
+#  if (!defined(__has_include) || (__cplusplus < 201700))
+#    define BOOST_STATIC_STRING_NO_CXX17_HDR_STRING_VIEW
+#  elif !__has_include(<string_view>)
+#    define BOOST_STATIC_STRING_NO_CXX17_HDR_STRING_VIEW
+#  endif
 #endif
 
 #if !defined(BOOST_STATIC_STRING_NO_CXX17_HDR_STRING_VIEW) || \

--- a/test/constexpr_tests.hpp
+++ b/test/constexpr_tests.hpp
@@ -171,8 +171,10 @@ testConstantEvaluation()
 
   a.substr(0);
 
+#ifdef BOOST_STATIC_STRING_HAS_ANY_STRING_VIEW
   // subview
   a.subview(0);
+#endif
 
   // copy
   char k[20]{};


### PR DESCRIPTION
The config.hpp uses `BOOST_LIBSTDCXX_VERSION` which isn't defined in
standalone mode so `BOOST_STATIC_STRING_NO_CXX17_HDR_STRING_VIEW` will
be defined.
This then causes build failures for code expecting the availability of
string_view.

First fix the test failure by checking for BOOST_STATIC_STRING_HAS_ANY_STRING_VIEW before using a function that requires a string_view