### PR TITLE
Make `basic_static_string` constructible and assignable from a C-style string in a constexpr context

### DIFF
--- a/include/boost/static_string/static_string.hpp
+++ b/include/boost/static_string/static_string.hpp
@@ -1202,7 +1202,7 @@ public:
   BOOST_STATIC_STRING_CPP14_CONSTEXPR
   basic_static_string(const_pointer s)
   {
-    assign(s);
+    assign(s, s + traits_type::length(s));
   }
 
   /** Constructor.
@@ -1373,7 +1373,7 @@ public:
   basic_static_string&
   operator=(const_pointer s)
   {
-    return assign(s);
+    return assign(s, s + traits_type::length(s));
   }
 
   /** Assign to the string.

--- a/test/constexpr_tests.hpp
+++ b/test/constexpr_tests.hpp
@@ -67,6 +67,22 @@ bool
 testConstantEvaluation()
 {
 #ifdef BOOST_STATIC_STRING_CPP20
+
+  // Check construction in a constexpr context
+  constexpr basic_static_string s("hello");
+  static_assert(s.size() == 5);
+  static_assert(s == "hello");
+
+  // Check assignment in a constexpr context
+  constexpr auto s2 =
+  []()
+  {
+    basic_static_string s("hello");
+    s = "world";
+    return s;
+  }();
+  static_assert(s2 == "world");
+
   // c++20 constexpr tests
   cstatic_string a;
   cstatic_string b(1, 'a');


### PR DESCRIPTION
Constructing or assigning from a C-style string in a constexpr context triggers a libstdc++ issue which was fixed in GCC 12.4 and 13.3: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=113200>. We add corresponding tests, and then a workaround for the issue.